### PR TITLE
Add colors to diff

### DIFF
--- a/colors/off.vim
+++ b/colors/off.vim
@@ -189,6 +189,9 @@ call s:h("htmlH4",        {"bg": s:bg, "fg": s:norm})
 call s:h("htmlH5",        {"bg": s:bg, "fg": s:norm})
 call s:h("htmlH6",        {"bg": s:bg, "fg": s:norm})
 
+hi link diffRemoved       DiffDelete
+hi link diffAdded         DiffAdd
+
 " Signify, git-gutter
 hi link SignifySignAdd              LineNr
 hi link SignifySignDelete           LineNr


### PR DESCRIPTION
Highlighting in diff files is essential. This minimal solution uses vimdiff highlighting groups. So it will be messy to compare two diffs. But it's pretty rare case.