### PR TITLE
Add Colors for Git & Fuzzy Search

### DIFF
--- a/colors/off.vim
+++ b/colors/off.vim
@@ -217,4 +217,8 @@ if colors_off_a_little
     hi! CtrlPMatch                   ctermbg=235 ctermfg=250 guibg=NONE guifg=#5FD7A7 cterm=NONE gui=NONE
     hi! TelescopeMatching            guifg=#5FD7A7 guibg=#303030 ctermbg=NONE
     highlight TelescopeSelection     guifg=NONE gui=bold guibg=#303030
+else
+    hi! CtrlPMatch                   ctermbg=NONE ctermfg=NONE guibg=NONE guifg=NONE cterm=NONE gui=bold
+    hi! TelescopeMatching            guifg=NONE guibg=NONE ctermbg=NONE
+    highlight TelescopeSelection     guifg=NONE gui=bold guibg=#303030
 endif

--- a/colors/off.vim
+++ b/colors/off.vim
@@ -214,6 +214,7 @@ endif
 
 " Fuzzy Search, Telescope & CtrlP
 if colors_off_a_little
-    hi! CtrlPMatch              ctermbg=235 ctermfg=250 guibg=NONE guifg=#5FD7A7 cterm=NONE gui=NONE
-    hi! TelescopeMatching       guifg=#5FD7A7
+    hi! CtrlPMatch                   ctermbg=235 ctermfg=250 guibg=NONE guifg=#5FD7A7 cterm=NONE gui=NONE
+    hi! TelescopeMatching            guifg=#5FD7A7 guibg=#303030 ctermbg=NONE
+    highlight TelescopeSelection     guifg=NONE gui=bold guibg=#303030
 endif

--- a/colors/off.vim
+++ b/colors/off.vim
@@ -16,6 +16,7 @@ if exists('syntax on')
 endif
 
 let g:colors_name='off'
+let colors_off_a_little = get(g:, 'colors_off_a_little', 0)
 
 let s:black           = { "gui": "#212121", "cterm": "0"   }
 let s:medium_gray     = { "gui": "#767676", "cterm": "243" }
@@ -199,7 +200,20 @@ hi link diffAdded         DiffAdd
 hi link SignifySignAdd              LineNr
 hi link SignifySignDelete           LineNr
 hi link SignifySignChange           LineNr
-hi link GitGutterAdd                LineNr
-hi link GitGutterDelete             LineNr
-hi link GitGutterChange             LineNr
-hi link GitGutterChangeDelete       LineNr
+if colors_off_a_little
+    hi! GitGutterAdd guifg=#10A778 ctermfg=2
+    hi! GitGutterChange guifg=#A89C14 ctermfg=3
+    hi! GitGutterDelete guifg=#C30771 ctermfg=1
+    hi! GitGutterChangeDelete guifg=#C30771 ctermfg=1
+else
+    hi link GitGutterAdd                LineNr
+    hi link GitGutterDelete             LineNr
+    hi link GitGutterChange             LineNr
+    hi link GitGutterChangeDelete       LineNr
+endif
+
+" Fuzzy Search, Telescope & CtrlP
+if colors_off_a_little
+    hi! CtrlPMatch              ctermbg=235 ctermfg=250 guibg=NONE guifg=#5FD7A7 cterm=NONE gui=NONE
+    hi! TelescopeMatching       guifg=#5FD7A7
+endif


### PR DESCRIPTION
Git diff
![Image of Git diff](https://i.imgur.com/MO8O5zt.png)


Telescope match diff (should be same for CtrlP match)
![Image of fuzzy search match](https://i.imgur.com/4Xldj1H.png)

enabling this by setting up in .vimrc
``` vim
let g:colors_off_a_little=1
```

if `colors_off_a_little` not defined, the result will be as default for git and for fuzzy search it will be like
![fuzzy search plain](https://i.imgur.com/TawXvTt.png)
![fuzzy search plain](https://i.imgur.com/eYxeZ8j.png)